### PR TITLE
add user email to auth credential

### DIFF
--- a/src/services/api/user/user.hooks.ts
+++ b/src/services/api/user/user.hooks.ts
@@ -12,6 +12,7 @@ import { IssuerEntity } from '../../../entities/Issuer';
 interface AuthCredentialSubject extends CredentialSubject {
   isAuthorized: true;
   userUuid: string;
+  userEmail: string;
 }
 
 interface KYCCredentialSubject extends CredentialSubject {
@@ -43,12 +44,13 @@ interface KYCCredentialSubject extends CredentialSubject {
   confidence: string;
 }
 
-type UserServiceHook = Hook<Partial<User>>;
+type UserServiceHook = Hook<User>;
 
-export const buildAuthCredentialSubject = (did: string, userUuid: string): AuthCredentialSubject => ({
+export const buildAuthCredentialSubject = (did: string, userUuid: string, userEmail: string): AuthCredentialSubject => ({
   id: did,
   isAuthorized: true,
-  userUuid
+  userUuid,
+  userEmail
 });
 
 export const buildKYCCredentialSubject = (did: string): KYCCredentialSubject => ({
@@ -138,10 +140,10 @@ export const getDefaultIssuerEntity: UserServiceHook = async (ctx) => {
 };
 
 export const issueAuthCredential: UserServiceHook = async (ctx) => {
-  const { id, data, params } = ctx;
+  const { id, data, result, params } = ctx;
   const defaultIssuerEntity = params.defaultIssuerEntity as IssuerEntity;
 
-  if (!data || !id) {
+  if (!data || !id || !result) {
     throw new BadRequest();
   }
 
@@ -156,7 +158,7 @@ export const issueAuthCredential: UserServiceHook = async (ctx) => {
   }
 
   // issue a DemoAuthCredential using the server sdk
-  const authCredentialSubject = buildAuthCredentialSubject(did, id as string);
+  const authCredentialSubject = buildAuthCredentialSubject(did, id as string, result.email);
   const issuerDto = await issueCredential(defaultIssuerEntity, authCredentialSubject, 'DemoAuthCredential');
 
   // store the issued credential

--- a/test/services/api/user/user.hooks.test.ts
+++ b/test/services/api/user/user.hooks.test.ts
@@ -32,10 +32,12 @@ describe('user api service hooks', () => {
       it('builds the CredentialSubject for a DemoAuthCredential with the provided did and userUuid', () => {
         const did = `did:unum:${v4}`;
         const userUuid = v4();
-        const authCredential = buildAuthCredentialSubject(did, userUuid);
+        const userEmail = 'test@unum.id';
+        const authCredential = buildAuthCredentialSubject(did, userUuid, userEmail);
         const expected = {
           id: did,
           userUuid,
+          userEmail,
           isAuthorized: true
         };
         expect(authCredential).toEqual(expected);
@@ -83,7 +85,8 @@ describe('user api service hooks', () => {
       const did = `did:unum:${v4}`;
       const userUuid = v4();
       const credentialType = 'DemoAuthCredential';
-      const credentialSubject = buildAuthCredentialSubject(did, userUuid);
+      const userEmail = 'test@unum.id';
+      const credentialSubject = buildAuthCredentialSubject(did, userUuid, userEmail);
 
       it('issues a credential using the server sdk', async () => {
         await issueCredential(dummyIssuerEntity, credentialSubject, credentialType);
@@ -194,9 +197,12 @@ describe('user api service hooks', () => {
       });
 
       it('throws if the defaultIssuerEntity param has not been set', async () => {
+        const userUuid = v4();
+        const did = `did:unum:${v4()}`;
         const ctx = {
-          data: { did: `did:unum:${v4()}` },
-          id: v4(),
+          data: { did },
+          result: { uuid: userUuid, email: 'test@unum.id', did },
+          id: userUuid,
           params: {}
         } as unknown as HookContext;
 
@@ -210,9 +216,12 @@ describe('user api service hooks', () => {
       });
 
       it('exits early if the did is not being updated', async () => {
+        const userUuid = v4();
+        const did = `did:unum:${v4()}`;
         const ctx = {
           data: { email: 'test@unumid.org' },
-          id: v4(),
+          id: userUuid,
+          result: { did, uuid: userUuid, email: 'test@unumid.org' },
           params: { defaultIssuerEntity: dummyIssuerEntity }
         } as unknown as HookContext;
 
@@ -234,9 +243,13 @@ describe('user api service hooks', () => {
           .mockReturnValueOnce(mockIssuerDataService);
 
         mockIssueCredential.mockResolvedValueOnce(dummyCredentialDto);
+        const userUuid = v4();
+        const did = `did:unum:${v4()}`;
+        const userEmail = 'test@unum.id';
         const ctx = {
-          data: { did: `did:unum:${v4()}` },
-          id: v4(),
+          data: { did },
+          id: userUuid,
+          result: { uuid: userUuid, did, email: userEmail },
           params: { defaultIssuerEntity: dummyIssuerEntity },
           app: {
             service: mockService
@@ -250,7 +263,7 @@ describe('user api service hooks', () => {
           formatBearerToken(dummyIssuerEntity.authToken),
           'DemoAuthCredential',
           dummyIssuerEntity.issuerDid,
-          buildAuthCredentialSubject(ctx.data.did, ctx.id as string),
+          buildAuthCredentialSubject(ctx.data.did, ctx.id as string, userEmail),
           dummyIssuerEntity.privateKey
         );
       });
@@ -269,9 +282,13 @@ describe('user api service hooks', () => {
           .mockReturnValueOnce(mockIssuerDataService);
 
         mockIssueCredential.mockResolvedValueOnce(dummyCredentialDto);
+        const userUuid = v4();
+        const did = `did:unum:${v4()}`;
+        const email = 'test@unum.id';
         const ctx = {
-          data: { did: `did:unum:${v4()}` },
-          id: v4(),
+          data: { did },
+          id: userUuid,
+          result: { uuid: userUuid, did, email },
           params: { defaultIssuerEntity: dummyIssuerEntity },
           app: {
             service: mockService
@@ -296,9 +313,15 @@ describe('user api service hooks', () => {
           .mockReturnValueOnce(mockIssuerDataService);
 
         mockIssueCredential.mockResolvedValueOnce(dummyCredentialDto);
+
+        const userUuid = v4();
+        const did = `did:unum:${v4()}`;
+        const email = 'test@unum.id';
+
         const ctx = {
-          data: { did: `did:unum:${v4()}` },
-          id: v4(),
+          data: { did },
+          id: userUuid,
+          result: { uuid: userUuid, did, email },
           params: { defaultIssuerEntity: dummyIssuerEntity },
           app: {
             service: mockService
@@ -336,9 +359,15 @@ describe('user api service hooks', () => {
           ...dummyCredentialDto,
           authToken: 'updated auth token'
         });
+
+        const userUuid = v4();
+        const did = `did:unum:${v4()}`;
+        const email = 'test@unum.id';
+
         const ctx = {
-          data: { did: `did:unum:${v4()}` },
-          id: v4(),
+          data: { did },
+          id: userUuid,
+          result: { uuid: userUuid, did, email },
           params: { defaultIssuerEntity: dummyIssuerEntity },
           app: {
             service: mockService
@@ -367,9 +396,15 @@ describe('user api service hooks', () => {
           ...dummyCredentialDto,
           authToken: 'updated auth token'
         });
+
+        const userUuid = v4();
+        const did = `did:unum:${v4()}`;
+        const email = 'test@unum.id';
+
         const ctx = {
-          data: { did: `did:unum:${v4()}` },
-          id: v4(),
+          data: { did },
+          id: userUuid,
+          result: { uuid: userUuid, did, email },
           params: { defaultIssuerEntity: dummyIssuerEntity },
           app: {
             service: mockService
@@ -397,9 +432,14 @@ describe('user api service hooks', () => {
       });
 
       it('throws if the defaultIssuerEntity param has not been set', async () => {
+        const userUuid = v4();
+        const did = `did:unum:${v4()}`;
+        const email = 'test@unum.id';
+
         const ctx = {
-          data: { did: `did:unum:${v4()}` },
-          id: v4(),
+          data: { did },
+          id: userUuid,
+          result: { uuid: userUuid, did, email },
           params: {}
         } as unknown as HookContext;
 
@@ -413,9 +453,14 @@ describe('user api service hooks', () => {
       });
 
       it('exits early if the did is not being updated', async () => {
+        const userUuid = v4();
+        const did = `did:unum:${v4()}`;
+        const email = 'test@unum.id';
+
         const ctx = {
-          data: { email: 'test@unumid.org' },
-          id: v4(),
+          data: { email },
+          id: userUuid,
+          result: { uuid: userUuid, did, email },
           params: { defaultIssuerEntity: dummyIssuerEntity }
         } as unknown as HookContext;
 
@@ -472,9 +517,14 @@ describe('user api service hooks', () => {
           .mockReturnValueOnce(mockIssuerDataService);
 
         mockIssueCredential.mockResolvedValueOnce(dummyCredentialDto);
+        const userUuid = v4();
+        const did = `did:unum:${v4()}`;
+        const email = 'test@unum.id';
+
         const ctx = {
-          data: { did: `did:unum:${v4()}` },
-          id: v4(),
+          data: { did },
+          id: userUuid,
+          result: { uuid: userUuid, did, email },
           params: { defaultIssuerEntity: dummyIssuerEntity },
           app: {
             service: mockService
@@ -539,9 +589,14 @@ describe('user api service hooks', () => {
           ...dummyCredentialDto,
           authToken: 'updated auth token'
         });
+        const userUuid = v4();
+        const did = `did:unum:${v4()}`;
+        const email = 'test@unum.id';
+
         const ctx = {
-          data: { did: `did:unum:${v4()}` },
-          id: v4(),
+          data: { did },
+          id: userUuid,
+          result: { uuid: userUuid, did, email },
           params: { defaultIssuerEntity: dummyIssuerEntity },
           app: {
             service: mockService
@@ -570,9 +625,14 @@ describe('user api service hooks', () => {
           ...dummyCredentialDto,
           authToken: 'updated auth token'
         });
+        const userUuid = v4();
+        const did = `did:unum:${v4()}`;
+        const email = 'test@unum.id';
+
         const ctx = {
-          data: { did: `did:unum:${v4()}` },
-          id: v4(),
+          data: { did },
+          id: userUuid,
+          result: { uuid: userUuid, did, email },
           params: { defaultIssuerEntity: dummyIssuerEntity },
           app: {
             service: mockService


### PR DESCRIPTION
[ticket](https://trello.com/c/ZJkQ4dnx/1248-add-user-email-to-demo-auth-credential)

## Summary
adds user email to the auth credential issued when a user's did is updated

## testing
- updated existing tests
- tested locally with postman
  - create a new user
  - create a subject in the dev saas
  - patch the user with the subject did

