### PR TITLE
[dockerfile] use npm ci instead of install

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,7 +14,7 @@ COPY package-lock.json /app/
 
 RUN mkdir -p -m 0600 ~/.ssh && ssh-keyscan github.com >> ~/.ssh/known_hosts
 
-RUN --mount=type=ssh,id=github npm install
+RUN --mount=type=ssh,id=github npm ci
 
 COPY ./ /app/
 


### PR DESCRIPTION
updates Dockerfile to use the `npm ci` command to install dependencies instead of the regular `npm install`. 

`npm ci` is specifically meant for CI/CD pipelines and similar use cases, and unlike `npm install` produces a deterministic, repeatable build.
https://docs.npmjs.com/cli/v7/commands/npm-ci
https://stackoverflow.com/questions/52499617/what-is-the-difference-between-npm-install-and-npm-ci