### PR TITLE
[User] set password to hidden:true instead of using custom toJSON met…

### DIFF
--- a/src/entities/User.ts
+++ b/src/entities/User.ts
@@ -1,11 +1,10 @@
 import {
   Entity,
   Property,
-  wrap,
   OneToMany,
   Collection
 } from '@mikro-orm/core';
-import { DemoUser, DemoUserCreateOptions } from '@unumid/demo-types';
+import { DemoUserCreateOptions } from '@unumid/demo-types';
 
 import { BaseEntity } from './BaseEntity';
 import { PushToken } from './PushToken';
@@ -20,7 +19,7 @@ export class User extends BaseEntity {
   @Property()
   phone?: string;
 
-  @Property()
+  @Property({ hidden: true })
   password: string;
 
   @Property()
@@ -41,20 +40,5 @@ export class User extends BaseEntity {
     this.phone = phone;
     this.password = password;
     this.firstName = firstName;
-  }
-
-  toJSON (ignoreFields?: string[]): DemoUser {
-    const record = wrap(this).toObject(ignoreFields);
-
-    const result = {
-      uuid: record.uuid,
-      createdAt: record.createdAt,
-      updatedAt: record.updatedAt,
-      email: record.email,
-      phone: record.phone,
-      did: record.did,
-      pushTokens: record.pushTokens
-    };
-    return result;
   }
 }

--- a/test/entities/User.test.ts
+++ b/test/entities/User.test.ts
@@ -1,4 +1,4 @@
-import { EntityRepository, MikroORM } from '@mikro-orm/core';
+import { EntityRepository, MikroORM, wrap } from '@mikro-orm/core';
 
 import { User } from '../../src/entities/User';
 import mikroOrmConfig from '../../src/mikro-orm.config';
@@ -73,6 +73,30 @@ describe('User entity', () => {
       expect(savedUser.did).toBeNull();
       expect(savedUser.phone).toBeNull();
       expect(savedUser.pushTokens.getItems()).toEqual([]);
+    });
+
+    it('serializes to json correctly', async () => {
+      const user2 = new User(options);
+      await userRepository.persistAndFlush(user2);
+      orm.em.clear();
+
+      const savedUser = await userRepository.findOneOrFail(user2.uuid, ['pushTokens']);
+
+      const users = await userRepository.findAll();
+      console.log('users', users);
+      const savedUserObj = wrap(savedUser).toPOJO();
+      const expected = {
+        uuid: savedUserObj.uuid,
+        createdAt: savedUserObj.createdAt,
+        updatedAt: savedUserObj.updatedAt,
+        email: savedUserObj.email,
+        phone: savedUserObj.phone,
+        firstName: savedUserObj.firstName,
+        did: savedUserObj.did,
+        pushTokens: savedUserObj.pushTokens
+      };
+
+      expect(wrap(savedUser).toJSON()).toEqual(expected);
     });
   });
 });


### PR DESCRIPTION
…hod for serialization

Sets `User` `password` property to `hidden: true` instead of using a custom `toJSON` method to exclude `password` from serialization. This should include any new properties added to `User` in serialization by default, so we are unlikely to forget them like I did with `firstName` in #15 