### PR TITLE
[authentication] populate push tokens for auth response

### DIFF
--- a/src/authentication.ts
+++ b/src/authentication.ts
@@ -29,7 +29,7 @@ class MyLocalStrategy extends LocalStrategy {
     // create and persist a userCode on the User entity before returning it
     const userDataService = this.app.service('userData');
     try {
-      const patchedUser = await userDataService.patch(authenticatedUser.uuid, { userCode: v4() }, params);
+      const patchedUser = await userDataService.patch(authenticatedUser.uuid, { userCode: v4() }, { ...params, populate: true });
       return patchedUser;
     } catch (e) {
       logger.error(`error in login's UserDataService.patch. ${e}`);

--- a/test/authentication.test.ts
+++ b/test/authentication.test.ts
@@ -1,8 +1,34 @@
+import { wrap } from '@mikro-orm/core';
 import generateApp from '../src/app';
+import { Application } from '../src/declarations';
+import { resetDb } from './helpers/resetDb';
 
 describe('authentication', () => {
   it('registered the authentication service', async () => {
     const app = await generateApp();
     expect(app.service('authentication')).toBeTruthy();
+  });
+
+  describe('local', () => {
+    let app: Application;
+
+    beforeEach(async () => {
+      app = await generateApp();
+    });
+
+    afterEach(async () => {
+      const orm = app.get('orm');
+      await resetDb(orm);
+    });
+
+    it('returns push tokens', async () => {
+      const user = await app.service('user').create({ email: 'test@unumid.co', password: 'test', firstName: 'test' });
+
+      // add a push token for the user
+      await app.service('pushToken').create({ value: 'test token', provider: 'APNS', userUuid: user.uuid });
+
+      const authResponse = await app.service('authentication').create({ strategy: 'local', email: 'test@unumid.co', password: 'test' }, {});
+      expect(authResponse.user.pushTokens.length).toEqual(1);
+    });
   });
 });


### PR DESCRIPTION
[ticket](https://trello.com/c/yQ1huF2R/2443-user-push-tokens-not-returned-in-authentication-result)

## Summary
Populates user push tokens when authenticating

## Changes
- adds `populate: true` to patch call in `MyLocalStrategy.getEntity`

## Testing
- added test for authentication response
- tested locally with client, confirmed push notification option is now available