### PR TITLE
add test credential request services

### DIFF
--- a/src/services/api/testCredentialRequests1/testCredentialRequests1.class.ts
+++ b/src/services/api/testCredentialRequests1/testCredentialRequests1.class.ts
@@ -1,0 +1,115 @@
+import { Params } from '@feathersjs/feathers';
+import { UnumDto, VerifiedStatus, verifySubjectCredentialRequests } from '@unumid/server-sdk';
+import { CredentialPb, CredentialRequest } from '@unumid/types';
+
+import { Application } from '../../../declarations';
+import { IssuerEntity } from '../../../entities/Issuer';
+import logger from '../../../logger';
+import { convertCredentialToCredentialEntityOptions } from '../../../utils/converters';
+import {
+  buildTest1ACredentialSubject,
+  buildTest1BCredentialSubject,
+  issueCredentialsHelper,
+  TestCredentialTypes
+} from '../../../utils/credentials';
+import { CredentialsIssuedResponse, UserCredentialRequests } from '../userCredentialRequests/userCredentialRequests.class';
+
+/**
+ * A service to use for testing more complex scenarios for the credential request/user code flow
+ * (not really part of the ACME demo)
+ * It will issue credentials of type 'Test1ACredential' and 'Test1BCredential' on request
+ * and will refuse to issue credentials of type 'Test2ACredential' and 'Test2BCredential'
+ */
+export class TestCredentialRequests1Service {
+  app: Application;
+
+  constructor (app: Application) {
+    this.app = app;
+  }
+
+  async create (data: UserCredentialRequests, params?: Params): Promise<CredentialsIssuedResponse> {
+    const issuer: IssuerEntity = params?.issuerEntity;
+
+    const { user, credentialRequestsInfo: { subjectCredentialRequests, issuerDid, subjectDid } } = data;
+
+    if (issuer.issuerDid !== issuerDid) {
+      throw new Error(`Persisted Issuer DID ${issuer.issuerDid} does not match request's issuer did ${issuerDid}`);
+    }
+
+    const verification: UnumDto<VerifiedStatus> = await verifySubjectCredentialRequests(issuer.authToken, issuer.issuerDid, subjectDid, subjectCredentialRequests);
+
+    if (!verification.body.isVerified) {
+      logger.error(`SubjectCredentialRequests could not be validated. Not issuing credentials. ${verification.body.message}`);
+      throw new Error(`SubjectCredentialRequests could not be validated. Not issuing credentials. ${verification.body.message}`);
+    }
+
+    // Note in the userDidAssociation hook we have already ensured that the user has an associated did.
+    const userDid = user.did as string;
+
+    /**
+     * Now that we have verified the credential requests signature signed by the subject, aka user, and we
+     * have confirmed to have a user with the matching did in our data store, we need some logic to determine if we can
+     * issue the requested credentials.
+     *
+     * For demonstration purposes just simply full-filling email, kyc and auth credential requests.
+     */
+    const credentialSubjects: TestCredentialTypes[] = [];
+    subjectCredentialRequests.credentialRequests.forEach((credentialRequest: CredentialRequest) => {
+      // This test issuer issues two types of credentials on request, Test1A and Test1B
+      // It does not issue credentials of type Test2A or Test2B
+      switch (credentialRequest.type) {
+        case 'Test1ACredential': {
+          credentialSubjects.push(buildTest1ACredentialSubject(userDid));
+          break;
+        }
+        case 'Test1BCredential': {
+          credentialSubjects.push(buildTest1BCredentialSubject(userDid));
+          break;
+        }
+        case 'Test2ACredential': {
+          logger.info('Test Issuer 1 does not issue Test2ACredential');
+          break;
+        }
+        case 'Test2BCredential': {
+          logger.info('Test Issuer 1 does not issue Test2BCredential');
+          break;
+        }
+        default: {
+          logger.info(`Test Issuer 1 received unexpected request for ${credentialRequest.type}`);
+        }
+      }
+    });
+
+    const issuerDto: UnumDto<CredentialPb[]> = await issueCredentialsHelper(issuer, userDid, credentialSubjects);
+
+    // store the issued credentials
+    const credentials: CredentialPb[] = issuerDto.body;
+    const credentialDataService = this.app.service('credentialData');
+
+    for (const issuedCredential of credentials) {
+      const credentialEntityOptions = convertCredentialToCredentialEntityOptions(issuedCredential);
+
+      try {
+        await credentialDataService.create(credentialEntityOptions);
+      } catch (e) {
+        logger.error('CredentialRequest create caught an error thrown by credentialDataService.create', e);
+        throw e;
+      }
+    }
+
+    // update the default issuer's auth token if it has been reissued
+    if (issuerDto.authToken !== issuer.authToken) {
+      const issuerDataService = this.app.service('issuerData');
+      try {
+        await issuerDataService.patch(issuer.uuid, { authToken: issuerDto.authToken });
+      } catch (e) {
+        logger.error('CredentialRequest create caught an error thrown by issuerDataService.patch', e);
+        throw e;
+      }
+    }
+
+    return {
+      credentialTypesIssued: credentialSubjects.map((credentialSubject: TestCredentialTypes) => credentialSubject.type)
+    };
+  }
+}

--- a/src/services/api/testCredentialRequests1/testCredentialRequests1.hooks.ts
+++ b/src/services/api/testCredentialRequests1/testCredentialRequests1.hooks.ts
@@ -1,0 +1,136 @@
+import { Hook } from '@feathersjs/feathers';
+
+import logger from '../../../logger';
+import { IssuerEntity } from '../../../entities/Issuer';
+import { User } from '../../../entities/User';
+import { UnumDto, revokeAllCredentials, VerifiedStatus, verifySignedDid } from '@unumid/server-sdk';
+import { SubjectCredentialRequestsEnrichedDto } from '@unumid/types';
+
+export const getIssuerEntity: Hook = async (ctx) => {
+  const issuerDataService = ctx.app.service('issuerData');
+  let issuerEntity: IssuerEntity;
+  try {
+    [issuerEntity] = await issuerDataService.find({ query: { issuerName: 'Test Issuer 1' } });
+
+    return {
+      ...ctx,
+      params: {
+        ...ctx.params,
+        issuerEntity
+      }
+
+    };
+  } catch (e) {
+    logger.error('getIssuerEntity hook caught an error thrown by issuerDataService.get', e);
+    throw e;
+  }
+};
+
+export const validateRequest: Hook = async (ctx) => {
+  const { params } = ctx;
+
+  if (!params.headers?.version) {
+    logger.info('CredentialRequest request made without version');
+  } else {
+    logger.info(`CredentialRequest request made with version ${params.headers?.version}`);
+  }
+
+  return ctx;
+};
+
+/**
+ * Grab and return the associated user. If useDidAssociation is passed update the user with the provided did.
+ * @param ctx
+ * @returns
+ */
+export const handleUserDidAssociation: Hook = async (ctx) => {
+  const { app, params } = ctx;
+
+  // need to get an existing user either by the userIdentifier or by the subjectDid
+  const userDataService = app.service('userData');
+  let user: User;
+
+  const issuer: IssuerEntity = params?.issuerEntity;
+  const data: SubjectCredentialRequestsEnrichedDto = ctx.data;
+
+  const { userDidAssociation, credentialRequestsInfo: { subjectDid } } = data;
+
+  // if no userDidAssociation as part of request body then it is assume this issuer already has the did associated with a user
+  if (!userDidAssociation) {
+    logger.debug('No new userDidAssociation in the userCredentialRequests');
+
+    // grabbing user by subjectDid
+    try {
+      user = await userDataService.get(null, { where: { did: subjectDid } }); // will throw exception if not found
+    } catch (e) {
+      logger.warn(`No user found with did ${subjectDid}. This should never happen.`);
+      throw e;
+    }
+
+    return {
+      ...ctx,
+      data: {
+        ...ctx.data,
+        user
+      }
+    };
+  }
+
+  const { userCode, did } = userDidAssociation;
+
+  try {
+    // assuming user code is the object id... TODO change to query based on attribute
+    user = await userDataService.get(null, { where: { userCode } }); // will throw exception if not found
+  } catch (e) {
+    logger.warn(`No user found with code ${userCode}. Can not associate the did ${did.id}.`);
+    throw e;
+  }
+
+  // verify the subject did document
+  const result: UnumDto<VerifiedStatus> = await verifySignedDid(issuer.authToken, issuer.issuerDid, did);
+
+  if (!result.body.isVerified) {
+    throw new Error(`${result.body.message} Subject DID document ${did.id} for user ${userCode} is not verified.`);
+  }
+
+  const userDid = did.id;
+
+  // if this is a new did association for the user then we need to revoke all the credentials associated with teh old did document
+  if (userDid !== user.did) {
+    // revoke all credentials associated with old did
+    await revokeAllCredentials(issuer.authToken, issuer.issuerDid, issuer.privateKey, userDid);
+
+    // update the user with the new did
+    await userDataService.patch(null, { did: userDid, userCode: null }, { where: { userCode } });
+  } else {
+    logger.debug('User association information sent with identical user did information. This should never happen.');
+    await userDataService.patch(null, { userCode: null }, { where: { userCode } }); // remove the userCode from the user
+  }
+
+  // update the default issuer's auth token if it has been reissued
+  if (result.authToken !== issuer.authToken) {
+    const issuerDataService = app.service('issuerData');
+    try {
+      await issuerDataService.patch(issuer.uuid, { authToken: result.authToken });
+    } catch (e) {
+      logger.error('CredentialRequest create caught an error thrown by issuerDataService.patch', e);
+      throw e;
+    }
+  }
+
+  return {
+    ...ctx,
+    data: {
+      ...ctx.data,
+      user
+    }
+  };
+};
+
+export const hooks = {
+  before: {
+    all: [validateRequest],
+    create: [getIssuerEntity, handleUserDidAssociation]
+  },
+  after: {}
+};

--- a/src/services/api/testCredentialRequests1/testCredentialRequests1.service.ts
+++ b/src/services/api/testCredentialRequests1/testCredentialRequests1.service.ts
@@ -1,0 +1,19 @@
+import { ServiceAddons } from '@feathersjs/feathers';
+
+import { Application } from '../../../declarations';
+import { hooks } from './testCredentialRequests1.hooks';
+import { TestCredentialRequests1Service } from './testCredentialRequests1.class';
+import { CredentialsIssuedResponse } from '@unumid/types';
+
+// add this service to the service type index
+declare module '../../../declarations' {
+  interface ServiceTypes {
+    'test1/userCredentialRequests': TestCredentialRequests1Service & ServiceAddons<CredentialsIssuedResponse>;
+  }
+}
+
+export default function (app: Application): void {
+  app.use('/test1/userCredentialRequests', new TestCredentialRequests1Service(app));
+  const service = app.service('test1/userCredentialRequests');
+  service.hooks(hooks);
+}

--- a/src/services/api/testCredentialRequests2/testCredentialRequests2.class.ts
+++ b/src/services/api/testCredentialRequests2/testCredentialRequests2.class.ts
@@ -1,0 +1,115 @@
+import { Params } from '@feathersjs/feathers';
+import { UnumDto, VerifiedStatus, verifySubjectCredentialRequests } from '@unumid/server-sdk';
+import { CredentialPb, CredentialRequest } from '@unumid/types';
+
+import { Application } from '../../../declarations';
+import { IssuerEntity } from '../../../entities/Issuer';
+import logger from '../../../logger';
+import { convertCredentialToCredentialEntityOptions } from '../../../utils/converters';
+import {
+  buildTest2ACredentialSubject,
+  buildTest2BCredentialSubject,
+  issueCredentialsHelper,
+  TestCredentialTypes
+} from '../../../utils/credentials';
+import { CredentialsIssuedResponse, UserCredentialRequests } from '../userCredentialRequests/userCredentialRequests.class';
+
+/**
+ * A service to use for testing more complex scenarios for the credential request/user code flow
+ * (not really part of the ACME demo)
+ * It will issue credentials of type 'Test2ACredential' and 'Test2BCredential' on request
+ * and will refuse to issue credentials of type 'Test1ACredential' and 'Test1BCredential'
+ */
+export class TestCredentialRequests2Service {
+  app: Application;
+
+  constructor (app: Application) {
+    this.app = app;
+  }
+
+  async create (data: UserCredentialRequests, params?: Params): Promise<CredentialsIssuedResponse> {
+    const issuer: IssuerEntity = params?.issuerEntity;
+
+    const { user, credentialRequestsInfo: { subjectCredentialRequests, issuerDid, subjectDid } } = data;
+
+    if (issuer.issuerDid !== issuerDid) {
+      throw new Error(`Persisted Issuer DID ${issuer.issuerDid} does not match request's issuer did ${issuerDid}`);
+    }
+
+    const verification: UnumDto<VerifiedStatus> = await verifySubjectCredentialRequests(issuer.authToken, issuer.issuerDid, subjectDid, subjectCredentialRequests);
+
+    if (!verification.body.isVerified) {
+      logger.error(`SubjectCredentialRequests could not be validated. Not issuing credentials. ${verification.body.message}`);
+      throw new Error(`SubjectCredentialRequests could not be validated. Not issuing credentials. ${verification.body.message}`);
+    }
+
+    // Note in the userDidAssociation hook we have already ensured that the user has an associated did.
+    const userDid = user.did as string;
+
+    /**
+     * Now that we have verified the credential requests signature signed by the subject, aka user, and we
+     * have confirmed to have a user with the matching did in our data store, we need some logic to determine if we can
+     * issue the requested credentials.
+     *
+     * For demonstration purposes just simply full-filling email, kyc and auth credential requests.
+     */
+    const credentialSubjects: TestCredentialTypes[] = [];
+    subjectCredentialRequests.credentialRequests.forEach((credentialRequest: CredentialRequest) => {
+      // This test issuer issues two types of credentials on request, Test1A and Test1B
+      // It does not issue credentials of type Test2A or Test2B
+      switch (credentialRequest.type) {
+        case 'Test2ACredential': {
+          credentialSubjects.push(buildTest2ACredentialSubject(userDid));
+          break;
+        }
+        case 'Test2BCredential': {
+          credentialSubjects.push(buildTest2BCredentialSubject(userDid));
+          break;
+        }
+        case 'Test1ACredential': {
+          logger.info('Test Issuer 2 does not issue Test2ACredential');
+          break;
+        }
+        case 'Test1BCredential': {
+          logger.info('Test Issuer 2 does not issue Test2BCredential');
+          break;
+        }
+        default: {
+          logger.info(`Test Issuer 2 received unexpected request for ${credentialRequest.type}`);
+        }
+      }
+    });
+
+    const issuerDto: UnumDto<CredentialPb[]> = await issueCredentialsHelper(issuer, userDid, credentialSubjects);
+
+    // store the issued credentials
+    const credentials: CredentialPb[] = issuerDto.body;
+    const credentialDataService = this.app.service('credentialData');
+
+    for (const issuedCredential of credentials) {
+      const credentialEntityOptions = convertCredentialToCredentialEntityOptions(issuedCredential);
+
+      try {
+        await credentialDataService.create(credentialEntityOptions);
+      } catch (e) {
+        logger.error('CredentialRequest create caught an error thrown by credentialDataService.create', e);
+        throw e;
+      }
+    }
+
+    // update the default issuer's auth token if it has been reissued
+    if (issuerDto.authToken !== issuer.authToken) {
+      const issuerDataService = this.app.service('issuerData');
+      try {
+        await issuerDataService.patch(issuer.uuid, { authToken: issuerDto.authToken });
+      } catch (e) {
+        logger.error('CredentialRequest create caught an error thrown by issuerDataService.patch', e);
+        throw e;
+      }
+    }
+
+    return {
+      credentialTypesIssued: credentialSubjects.map((credentialSubject: TestCredentialTypes) => credentialSubject.type)
+    };
+  }
+}

--- a/src/services/api/testCredentialRequests2/testCredentialRequests2.hooks.ts
+++ b/src/services/api/testCredentialRequests2/testCredentialRequests2.hooks.ts
@@ -1,0 +1,136 @@
+import { Hook } from '@feathersjs/feathers';
+
+import logger from '../../../logger';
+import { IssuerEntity } from '../../../entities/Issuer';
+import { User } from '../../../entities/User';
+import { UnumDto, revokeAllCredentials, VerifiedStatus, verifySignedDid } from '@unumid/server-sdk';
+import { SubjectCredentialRequestsEnrichedDto } from '@unumid/types';
+
+export const getIssuerEntity: Hook = async (ctx) => {
+  const issuerDataService = ctx.app.service('issuerData');
+  let issuerEntity: IssuerEntity;
+  try {
+    [issuerEntity] = await issuerDataService.find({ query: { issuerName: 'Test Issuer 2' } });
+
+    return {
+      ...ctx,
+      params: {
+        ...ctx.params,
+        issuerEntity
+      }
+
+    };
+  } catch (e) {
+    logger.error('getIssuerEntity hook caught an error thrown by issuerDataService.get', e);
+    throw e;
+  }
+};
+
+export const validateRequest: Hook = async (ctx) => {
+  const { params } = ctx;
+
+  if (!params.headers?.version) {
+    logger.info('CredentialRequest request made without version');
+  } else {
+    logger.info(`CredentialRequest request made with version ${params.headers?.version}`);
+  }
+
+  return ctx;
+};
+
+/**
+ * Grab and return the associated user. If useDidAssociation is passed update the user with the provided did.
+ * @param ctx
+ * @returns
+ */
+export const handleUserDidAssociation: Hook = async (ctx) => {
+  const { app, params } = ctx;
+
+  // need to get an existing user either by the userIdentifier or by the subjectDid
+  const userDataService = app.service('userData');
+  let user: User;
+
+  const issuer: IssuerEntity = params?.issuerEntity;
+  const data: SubjectCredentialRequestsEnrichedDto = ctx.data;
+
+  const { userDidAssociation, credentialRequestsInfo: { subjectDid } } = data;
+
+  // if no userDidAssociation as part of request body then it is assume this issuer already has the did associated with a user
+  if (!userDidAssociation) {
+    logger.debug('No new userDidAssociation in the userCredentialRequests');
+
+    // grabbing user by subjectDid
+    try {
+      user = await userDataService.get(null, { where: { did: subjectDid } }); // will throw exception if not found
+    } catch (e) {
+      logger.warn(`No user found with did ${subjectDid}. This should never happen.`);
+      throw e;
+    }
+
+    return {
+      ...ctx,
+      data: {
+        ...ctx.data,
+        user
+      }
+    };
+  }
+
+  const { userCode, did } = userDidAssociation;
+
+  try {
+    // assuming user code is the object id... TODO change to query based on attribute
+    user = await userDataService.get(null, { where: { userCode } }); // will throw exception if not found
+  } catch (e) {
+    logger.warn(`No user found with code ${userCode}. Can not associate the did ${did.id}.`);
+    throw e;
+  }
+
+  // verify the subject did document
+  const result: UnumDto<VerifiedStatus> = await verifySignedDid(issuer.authToken, issuer.issuerDid, did);
+
+  if (!result.body.isVerified) {
+    throw new Error(`${result.body.message} Subject DID document ${did.id} for user ${userCode} is not verified.`);
+  }
+
+  const userDid = did.id;
+
+  // if this is a new did association for the user then we need to revoke all the credentials associated with teh old did document
+  if (userDid !== user.did) {
+    // revoke all credentials associated with old did
+    await revokeAllCredentials(issuer.authToken, issuer.issuerDid, issuer.privateKey, userDid);
+
+    // update the user with the new did
+    await userDataService.patch(null, { did: userDid, userCode: null }, { where: { userCode } });
+  } else {
+    logger.debug('User association information sent with identical user did information. This should never happen.');
+    await userDataService.patch(null, { userCode: null }, { where: { userCode } }); // remove the userCode from the user
+  }
+
+  // update the default issuer's auth token if it has been reissued
+  if (result.authToken !== issuer.authToken) {
+    const issuerDataService = app.service('issuerData');
+    try {
+      await issuerDataService.patch(issuer.uuid, { authToken: result.authToken });
+    } catch (e) {
+      logger.error('CredentialRequest create caught an error thrown by issuerDataService.patch', e);
+      throw e;
+    }
+  }
+
+  return {
+    ...ctx,
+    data: {
+      ...ctx.data,
+      user
+    }
+  };
+};
+
+export const hooks = {
+  before: {
+    all: [validateRequest],
+    create: [getIssuerEntity, handleUserDidAssociation]
+  },
+  after: {}
+};

--- a/src/services/api/testCredentialRequests2/testCredentialRequests2.service.ts
+++ b/src/services/api/testCredentialRequests2/testCredentialRequests2.service.ts
@@ -1,0 +1,19 @@
+import { ServiceAddons } from '@feathersjs/feathers';
+
+import { Application } from '../../../declarations';
+import { hooks } from './testCredentialRequests2.hooks';
+import { TestCredentialRequests2Service } from './testCredentialRequests2.class';
+import { CredentialsIssuedResponse } from '@unumid/types';
+
+// add this service to the service type index
+declare module '../../../declarations' {
+  interface ServiceTypes {
+    'test2/userCredentialRequests': TestCredentialRequests2Service & ServiceAddons<CredentialsIssuedResponse>;
+  }
+}
+
+export default function (app: Application): void {
+  app.use('/test2/userCredentialRequests', new TestCredentialRequests2Service(app));
+  const service = app.service('test2/userCredentialRequests');
+  service.hooks(hooks);
+}

--- a/src/services/index.ts
+++ b/src/services/index.ts
@@ -9,7 +9,8 @@ import credential from './api/credential/credential.service';
 import pushToken from './api/pushToken/pushToken.service';
 import pushNotification from './api/pushNotification/pushNotification.service';
 import userCredentialRequests from './api/userCredentialRequests/userCredentialRequests.service';
-
+import testCredentialRequests1 from './api/testCredentialRequests1/testCredentialRequests1.service';
+import testCredentialRequests2 from './api/testCredentialRequests2/testCredentialRequests2.service';
 // eslint-disable-next-line @typescript-eslint/no-empty-function
 export default function (app: Application): void {
   app.configure(userCredentialRequests);
@@ -22,4 +23,6 @@ export default function (app: Application): void {
   app.configure(credential);
   app.configure(pushToken);
   app.configure(pushNotification);
+  app.configure(testCredentialRequests1);
+  app.configure(testCredentialRequests2);
 }

--- a/src/utils/credentials.ts
+++ b/src/utils/credentials.ts
@@ -93,6 +93,43 @@ export const buildKYCCredentialSubject = (did: string, firstName: string): KYCCr
   confidence: '99%'
 });
 
+// test credential types
+export interface Test1ACredentialSubject extends CredentialSubject {
+  type: 'Test1ACredential'
+}
+
+export interface Test1BCredentialSubject extends CredentialSubject {
+  type: 'Test1BCredential'
+}
+
+export interface Test2ACredentialSubject extends CredentialSubject {
+  type: 'Test2ACredential'
+}
+
+export interface Test2BCredentialSubject extends CredentialSubject {
+  type: 'Test2BCredential'
+}
+
+export type TestCredentialTypes = Test1ACredentialSubject | Test1BCredentialSubject | Test2ACredentialSubject | Test2BCredentialSubject;
+
+export const buildTest1ACredentialSubject = (did: string): Test1ACredentialSubject => ({
+  type: 'Test1ACredential',
+  id: did
+});
+
+export const buildTest1BCredentialSubject = (did: string): Test1BCredentialSubject => ({
+  type: 'Test1BCredential',
+  id: did
+});
+export const buildTest2ACredentialSubject = (did: string): Test2ACredentialSubject => ({
+  type: 'Test2ACredential',
+  id: did
+});
+export const buildTest2BCredentialSubject = (did: string): Test2BCredentialSubject => ({
+  type: 'Test2BCredential',
+  id: did
+});
+
 export const issueCredentialsHelper = async (
   issuerEntity: IssuerEntity,
   credentialSubject: string,


### PR DESCRIPTION
[ticket](https://trello.com/c/07BaPYhe/2437-add-new-test-issuer-endpoints-to-acme-issuer-server)

## Summary
Adds credential request endpoints for two new "test" issuers to be used for testing more complex scenarios for the credential request flow. Each endpoint has two test credential types it is hardcoded to always issue when requested, and two it will never issue.

## Changes
- adds `TestCredentialRequest1Service`
- adds `TestCredentialRequest2Service`