### PR TITLE
get appropriate issuer dids from env vars

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -22,3 +22,10 @@ UNUM_ENV=sandbox
 LOG_LEVEL=debug
 
 FIREBASE_CONFIG=
+
+# issuer to use for normal demo credentials
+DEFAULT_ISSUER_DID=
+# test issuer to use for testCredentialRequests1 endpoint
+TEST_ISSUER_DID_1=
+# test issuer to use for testCredentialRequests2 endpoint
+TEST_ISSUER_DID_2=

--- a/src/config.ts
+++ b/src/config.ts
@@ -4,7 +4,7 @@ import { isTestEnv } from './utils/isTestEnv';
 
 dotenv.config();
 
-interface Config {
+export interface Config {
   NODE_ENV: string;
   PAPERTRAIL_PORT: number;
   LOG_LEVEL: string;
@@ -15,6 +15,9 @@ interface Config {
   DB_PASSWORD: string;
   FIREBASE_CONFIG: Record<string, string>;
   APP_URL: string;
+  DEFAULT_ISSUER_DID: string;
+  TEST_ISSUER_DID_1: string;
+  TEST_ISSUER_DID_2: string;
 }
 
 const {
@@ -32,7 +35,10 @@ const {
   TEST_DB_USER = '',
   TEST_DB_PASSWORD = '',
   FIREBASE_CONFIG = '{}',
-  APP_URL = 'api.corp.com'
+  APP_URL = 'api.corp.com',
+  DEFAULT_ISSUER_DID = '',
+  TEST_ISSUER_DID_1 = '',
+  TEST_ISSUER_DID_2 = ''
 } = process.env;
 
 const dbConfig = isTestEnv(NODE_ENV)
@@ -57,5 +63,8 @@ export const config: Config = {
   LOG_LEVEL,
   FIREBASE_CONFIG: JSON.parse(FIREBASE_CONFIG),
   APP_URL,
+  DEFAULT_ISSUER_DID,
+  TEST_ISSUER_DID_1,
+  TEST_ISSUER_DID_2,
   ...dbConfig
 };

--- a/src/services/api/testCredentialRequests1/testCredentialRequests1.hooks.ts
+++ b/src/services/api/testCredentialRequests1/testCredentialRequests1.hooks.ts
@@ -5,12 +5,13 @@ import { IssuerEntity } from '../../../entities/Issuer';
 import { User } from '../../../entities/User';
 import { UnumDto, revokeAllCredentials, VerifiedStatus, verifySignedDid } from '@unumid/server-sdk';
 import { SubjectCredentialRequestsEnrichedDto } from '@unumid/types';
+import { config } from '../../../config';
 
 export const getIssuerEntity: Hook = async (ctx) => {
   const issuerDataService = ctx.app.service('issuerData');
   let issuerEntity: IssuerEntity;
   try {
-    [issuerEntity] = await issuerDataService.find({ query: { issuerName: 'Test Issuer 1' } });
+    issuerEntity = await issuerDataService.getByDid(config.TEST_ISSUER_DID_1);
 
     return {
       ...ctx,
@@ -21,7 +22,7 @@ export const getIssuerEntity: Hook = async (ctx) => {
 
     };
   } catch (e) {
-    logger.error('getIssuerEntity hook caught an error thrown by issuerDataService.get', e);
+    logger.error('getIssuerEntity hook caught an error thrown by issuerDataService.getByDid', e);
     throw e;
   }
 };

--- a/src/services/api/testCredentialRequests2/testCredentialRequests2.hooks.ts
+++ b/src/services/api/testCredentialRequests2/testCredentialRequests2.hooks.ts
@@ -5,12 +5,13 @@ import { IssuerEntity } from '../../../entities/Issuer';
 import { User } from '../../../entities/User';
 import { UnumDto, revokeAllCredentials, VerifiedStatus, verifySignedDid } from '@unumid/server-sdk';
 import { SubjectCredentialRequestsEnrichedDto } from '@unumid/types';
+import { config } from '../../../config';
 
 export const getIssuerEntity: Hook = async (ctx) => {
   const issuerDataService = ctx.app.service('issuerData');
   let issuerEntity: IssuerEntity;
   try {
-    [issuerEntity] = await issuerDataService.find({ query: { issuerName: 'Test Issuer 2' } });
+    issuerEntity = await issuerDataService.getByDid(config.TEST_ISSUER_DID_2);
 
     return {
       ...ctx,
@@ -21,7 +22,7 @@ export const getIssuerEntity: Hook = async (ctx) => {
 
     };
   } catch (e) {
-    logger.error('getIssuerEntity hook caught an error thrown by issuerDataService.get', e);
+    logger.error('getIssuerEntity hook caught an error thrown by issuerDataService.getByDid', e);
     throw e;
   }
 };

--- a/src/services/data/issuer.data.service.ts
+++ b/src/services/data/issuer.data.service.ts
@@ -4,15 +4,29 @@ import { ServiceAddons } from '@feathersjs/feathers';
 import { Application } from '../../declarations';
 import { IssuerEntity } from '../../entities/Issuer';
 import logger from '../../logger';
-import { isPaginated } from '../../typeguards';
+import { config } from '../../config';
 
-class IssuerDataService extends MikroOrmService<IssuerEntity> {
+export class IssuerDataService extends MikroOrmService<IssuerEntity> {
   async getDefaultIssuerEntity (): Promise<IssuerEntity> {
     try {
-      const issuerEntities = await this.find();
-      return isPaginated<IssuerEntity>(issuerEntities) ? issuerEntities.data[0] : issuerEntities[0];
+      return await this.getByDid(config.DEFAULT_ISSUER_DID);
     } catch (e) {
-      logger.error('IssuerDataService.getDefaultEntity caught an error thrown by this.find', e);
+      logger.error('IssuerDataService.getDefaultEntity caught an error thrown by this.getByDid', e);
+      throw e;
+    }
+  }
+
+  /**
+   * gets an issuer by did
+   * alias for IssuerDataService.get(null, { query: { did: did } })
+   * @param {string} did
+   * @returns {Promise<IssuerEntity>}
+   */
+  async getByDid (did: string): Promise<IssuerEntity> {
+    try {
+      return await this.get(null, { where: { issuerDid: did } });
+    } catch (e) {
+      logger.error('IssuerDataService.getByDid caught an error thrown by this.get', e);
       throw e;
     }
   }
@@ -20,7 +34,7 @@ class IssuerDataService extends MikroOrmService<IssuerEntity> {
 
 declare module '../../declarations' {
   interface ServiceTypes {
-    issuerData: MikroOrmService<IssuerEntity> & ServiceAddons<IssuerEntity>;
+    issuerData: IssuerDataService & ServiceAddons<IssuerEntity>;
   }
 }
 

--- a/test/services/api/user/user.hooks.test.ts
+++ b/test/services/api/user/user.hooks.test.ts
@@ -20,7 +20,6 @@ import { formatBearerToken } from '../../../../src/utils/formatBearerToken';
 import {
   dummyCredentialDto,
   dummyCredentialEntityOptions,
-  dummyCredentialEntityOptions,
   dummyCredentialsDto,
   dummyCredentialSubject,
   dummyIssuerEntity,


### PR DESCRIPTION
[Ticket](https://trello.com/c/b8c2GfgU/2476-dev-credentials-issued-by-wrong-issuer)

## Summary
Gets issuers by dids from env vars instead of using the first retrieved (default) or hardcoded names (test1 and test2)

## Changes
- adds `DEFAULT_ISSUER_DID`, `TEST_ISSUER_DID_1`, `TEST_ISSUER_DID_2` to env + config
- updates `IssuerDataService.getDefaultIssuerEntity` to get by default issuer did
- adds `IssuerDataService.getByDid` helper
- gets test issuers using `getByDid` with the corresponding did from config

## Testing
- added unit tests for `IssuerDataService.getByDid` and `IssuerDataService.getDefaultIssuerEntity`
- tested default issuer by patching a user using postman
- tested test issuers by creating a request for credentials from them via postman and using local web wallet to run credential request flow