### PR TITLE
[TestCredentialRequests] add more test credential types

### DIFF
--- a/src/services/api/testCredentialRequests1/testCredentialRequests1.class.ts
+++ b/src/services/api/testCredentialRequests1/testCredentialRequests1.class.ts
@@ -9,6 +9,8 @@ import { convertCredentialToCredentialEntityOptions } from '../../../utils/conve
 import {
   buildTest1ACredentialSubject,
   buildTest1BCredentialSubject,
+  buildTest4ACredentialSubject,
+  buildTest4BCredentialSubject,
   issueCredentialsHelper,
   TestCredentialTypes
 } from '../../../utils/credentials';
@@ -55,8 +57,8 @@ export class TestCredentialRequests1Service {
      */
     const credentialSubjects: TestCredentialTypes[] = [];
     subjectCredentialRequests.credentialRequests.forEach((credentialRequest: CredentialRequest) => {
-      // This test issuer issues two types of credentials on request, Test1A and Test1B
-      // It does not issue credentials of type Test2A or Test2B
+      // This test issuer issues four types of credentials on request, Test1A, Test1B, Test4A and Test4B
+      // It does not issue credentials of type Test2A, Test2B, Test3A, or Test3B
       switch (credentialRequest.type) {
         case 'Test1ACredential': {
           credentialSubjects.push(buildTest1ACredentialSubject(userDid));
@@ -72,6 +74,22 @@ export class TestCredentialRequests1Service {
         }
         case 'Test2BCredential': {
           logger.info('Test Issuer 1 does not issue Test2BCredential');
+          break;
+        }
+        case 'Test3ACredential': {
+          logger.info('Test Issuer 1 does not issue Test3ACredential');
+          break;
+        }
+        case 'Test3BCredential': {
+          logger.info('Test Issuer 1 does not issue Test3BCredential');
+          break;
+        }
+        case 'Test4ACredential': {
+          credentialSubjects.push(buildTest4ACredentialSubject(userDid));
+          break;
+        }
+        case 'Test4BCredential': {
+          credentialSubjects.push(buildTest4BCredentialSubject(userDid));
           break;
         }
         default: {

--- a/src/services/api/testCredentialRequests2/testCredentialRequests2.class.ts
+++ b/src/services/api/testCredentialRequests2/testCredentialRequests2.class.ts
@@ -9,6 +9,8 @@ import { convertCredentialToCredentialEntityOptions } from '../../../utils/conve
 import {
   buildTest2ACredentialSubject,
   buildTest2BCredentialSubject,
+  buildTest4ACredentialSubject,
+  buildTest4BCredentialSubject,
   issueCredentialsHelper,
   TestCredentialTypes
 } from '../../../utils/credentials';
@@ -55,8 +57,8 @@ export class TestCredentialRequests2Service {
      */
     const credentialSubjects: TestCredentialTypes[] = [];
     subjectCredentialRequests.credentialRequests.forEach((credentialRequest: CredentialRequest) => {
-      // This test issuer issues two types of credentials on request, Test1A and Test1B
-      // It does not issue credentials of type Test2A or Test2B
+      // This test issuer issues four types of credentials on request, Test2A, Test2B, Test4A, and Test4B
+      // It does not issue credentials of type Test1A, Test1B, Test3A, or Test3B
       switch (credentialRequest.type) {
         case 'Test2ACredential': {
           credentialSubjects.push(buildTest2ACredentialSubject(userDid));
@@ -72,6 +74,22 @@ export class TestCredentialRequests2Service {
         }
         case 'Test1BCredential': {
           logger.info('Test Issuer 2 does not issue Test2BCredential');
+          break;
+        }
+        case 'Test3ACredential': {
+          logger.info('Test Issuer 2 does not issue Test3ACredential');
+          break;
+        }
+        case 'Test3BCredential': {
+          logger.info('Test Issuer 2 does not issue Test3BCredential');
+          break;
+        }
+        case 'Test4ACredential': {
+          credentialSubjects.push(buildTest4ACredentialSubject(userDid));
+          break;
+        }
+        case 'Test4BCredential': {
+          credentialSubjects.push(buildTest4BCredentialSubject(userDid));
           break;
         }
         default: {

--- a/src/utils/credentials.ts
+++ b/src/utils/credentials.ts
@@ -94,6 +94,8 @@ export const buildKYCCredentialSubject = (did: string, firstName: string): KYCCr
 });
 
 // test credential types
+
+// will be issued only by test issuer 1
 export interface Test1ACredentialSubject extends CredentialSubject {
   type: 'Test1ACredential'
 }
@@ -102,6 +104,7 @@ export interface Test1BCredentialSubject extends CredentialSubject {
   type: 'Test1BCredential'
 }
 
+// will be issued only by test issuer 2
 export interface Test2ACredentialSubject extends CredentialSubject {
   type: 'Test2ACredential'
 }
@@ -110,7 +113,33 @@ export interface Test2BCredentialSubject extends CredentialSubject {
   type: 'Test2BCredential'
 }
 
-export type TestCredentialTypes = Test1ACredentialSubject | Test1BCredentialSubject | Test2ACredentialSubject | Test2BCredentialSubject;
+// will not be issued by either test issuer
+export interface Test3ACredentialSubject extends CredentialSubject {
+  type: 'Test3ACredential'
+}
+
+export interface Test3BCredentialSubject extends CredentialSubject {
+  type: 'Test3BCredential'
+}
+
+// will be issued by both test issuers
+export interface Test4ACredentialSubject extends CredentialSubject {
+  type: 'Test4ACredential'
+}
+
+export interface Test4BCredentialSubject extends CredentialSubject {
+  type: 'Test4BCredential'
+}
+
+export type TestCredentialTypes =
+  | Test1ACredentialSubject
+  | Test1BCredentialSubject
+  | Test2ACredentialSubject
+  | Test2BCredentialSubject
+  | Test3ACredentialSubject
+  | Test3BCredentialSubject
+  | Test4ACredentialSubject
+  | Test4BCredentialSubject;
 
 export const buildTest1ACredentialSubject = (did: string): Test1ACredentialSubject => ({
   type: 'Test1ACredential',
@@ -127,6 +156,26 @@ export const buildTest2ACredentialSubject = (did: string): Test2ACredentialSubje
 });
 export const buildTest2BCredentialSubject = (did: string): Test2BCredentialSubject => ({
   type: 'Test2BCredential',
+  id: did
+});
+
+export const buildTest3ACredentialSubject = (did: string): Test3ACredentialSubject => ({
+  type: 'Test3ACredential',
+  id: did
+});
+
+export const buildTest3BCredentialSubject = (did: string): Test3BCredentialSubject => ({
+  type: 'Test3BCredential',
+  id: did
+});
+
+export const buildTest4ACredentialSubject = (did: string): Test4ACredentialSubject => ({
+  type: 'Test4ACredential',
+  id: did
+});
+
+export const buildTest4BCredentialSubject = (did: string): Test4BCredentialSubject => ({
+  type: 'Test4BCredential',
   id: did
 });
 


### PR DESCRIPTION
[Ticket](https://trello.com/c/07BaPYhe/2437-add-new-test-issuer-endpoints-to-acme-issuer-server)

## Summary
Adds more test credential types for testing credential request flows

## Changes
- adds `Test3ACredential` and `Test3BCredential` credential types that will not be issued by either test issuer
- adds `Test4ACredential` and `Test4BCredential` credential types that will be issued by both test issuers