### PR TITLE
Credential request hooks

### DIFF
--- a/src/app.hooks.ts
+++ b/src/app.hooks.ts
@@ -19,7 +19,7 @@ function logError (ctx: HookContext): void {
     info.params.authToken = '*****';
   }
 
-  logger.warn(`Error in ${path}#${method}: name=${name} code=${code} message=${message}`, info);
+  logger.warn(`Error in ${path}#${method}: name=${name} code=${code} message=${message} info=${info}`);
 }
 
 function log (ctx: HookContext): void {

--- a/src/services/api/testCredentialRequests1/testCredentialRequests1.hooks.ts
+++ b/src/services/api/testCredentialRequests1/testCredentialRequests1.hooks.ts
@@ -1,35 +1,14 @@
 import { Hook } from '@feathersjs/feathers';
 
-import logger from '../../../logger';
-import { IssuerEntity } from '../../../entities/Issuer';
 import { config } from '../../../config';
 import { handleUserDidAssociation } from '../../hooks/handleUserDidAssociation';
 import { validateCredentialRequest } from '../../hooks/validateCredentialRequest';
-
-export const getIssuerEntity: Hook = async (ctx) => {
-  const issuerDataService = ctx.app.service('issuerData');
-  let issuerEntity: IssuerEntity;
-  try {
-    issuerEntity = await issuerDataService.getByDid(config.TEST_ISSUER_DID_1);
-
-    return {
-      ...ctx,
-      params: {
-        ...ctx.params,
-        issuerEntity
-      }
-
-    };
-  } catch (e) {
-    logger.error('getIssuerEntity hook caught an error thrown by issuerDataService.getByDid', e);
-    throw e;
-  }
-};
+import { getIssuerEntity } from '../../hooks/getIssuerEntity';
 
 export const hooks = {
   before: {
     all: [validateCredentialRequest],
-    create: [getIssuerEntity, handleUserDidAssociation]
+    create: [getIssuerEntity(config.TEST_ISSUER_DID_1), handleUserDidAssociation]
   },
   after: {}
 };

--- a/src/services/api/testCredentialRequests1/testCredentialRequests1.hooks.ts
+++ b/src/services/api/testCredentialRequests1/testCredentialRequests1.hooks.ts
@@ -2,10 +2,8 @@ import { Hook } from '@feathersjs/feathers';
 
 import logger from '../../../logger';
 import { IssuerEntity } from '../../../entities/Issuer';
-import { User } from '../../../entities/User';
-import { UnumDto, revokeAllCredentials, VerifiedStatus, verifySignedDid } from '@unumid/server-sdk';
-import { SubjectCredentialRequestsEnrichedDto } from '@unumid/types';
 import { config } from '../../../config';
+import { handleUserDidAssociation } from '../../hooks/handleUserDidAssociation';
 
 export const getIssuerEntity: Hook = async (ctx) => {
   const issuerDataService = ctx.app.service('issuerData');
@@ -37,95 +35,6 @@ export const validateRequest: Hook = async (ctx) => {
   }
 
   return ctx;
-};
-
-/**
- * Grab and return the associated user. If useDidAssociation is passed update the user with the provided did.
- * @param ctx
- * @returns
- */
-export const handleUserDidAssociation: Hook = async (ctx) => {
-  const { app, params } = ctx;
-
-  // need to get an existing user either by the userIdentifier or by the subjectDid
-  const userDataService = app.service('userData');
-  let user: User;
-
-  const issuer: IssuerEntity = params?.issuerEntity;
-  const data: SubjectCredentialRequestsEnrichedDto = ctx.data;
-
-  const { userDidAssociation, credentialRequestsInfo: { subjectDid } } = data;
-
-  // if no userDidAssociation as part of request body then it is assume this issuer already has the did associated with a user
-  if (!userDidAssociation) {
-    logger.debug('No new userDidAssociation in the userCredentialRequests');
-
-    // grabbing user by subjectDid
-    try {
-      user = await userDataService.get(null, { where: { did: subjectDid } }); // will throw exception if not found
-    } catch (e) {
-      logger.warn(`No user found with did ${subjectDid}. This should never happen.`);
-      throw e;
-    }
-
-    return {
-      ...ctx,
-      data: {
-        ...ctx.data,
-        user
-      }
-    };
-  }
-
-  const { userCode, did } = userDidAssociation;
-
-  try {
-    // assuming user code is the object id... TODO change to query based on attribute
-    user = await userDataService.get(null, { where: { userCode } }); // will throw exception if not found
-  } catch (e) {
-    logger.warn(`No user found with code ${userCode}. Can not associate the did ${did.id}.`);
-    throw e;
-  }
-
-  // verify the subject did document
-  const result: UnumDto<VerifiedStatus> = await verifySignedDid(issuer.authToken, issuer.issuerDid, did);
-
-  if (!result.body.isVerified) {
-    throw new Error(`${result.body.message} Subject DID document ${did.id} for user ${userCode} is not verified.`);
-  }
-
-  const userDid = did.id;
-
-  // if this is a new did association for the user then we need to revoke all the credentials associated with teh old did document
-  if (userDid !== user.did) {
-    // revoke all credentials associated with old did
-    await revokeAllCredentials(issuer.authToken, issuer.issuerDid, issuer.privateKey, userDid);
-
-    // update the user with the new did
-    await userDataService.patch(null, { did: userDid, userCode: null }, { where: { userCode } });
-  } else {
-    logger.debug('User association information sent with identical user did information. This should never happen.');
-    await userDataService.patch(null, { userCode: null }, { where: { userCode } }); // remove the userCode from the user
-  }
-
-  // update the default issuer's auth token if it has been reissued
-  if (result.authToken !== issuer.authToken) {
-    const issuerDataService = app.service('issuerData');
-    try {
-      await issuerDataService.patch(issuer.uuid, { authToken: result.authToken });
-    } catch (e) {
-      logger.error('CredentialRequest create caught an error thrown by issuerDataService.patch', e);
-      throw e;
-    }
-  }
-
-  return {
-    ...ctx,
-    data: {
-      ...ctx.data,
-      user
-    }
-  };
 };
 
 export const hooks = {

--- a/src/services/api/testCredentialRequests1/testCredentialRequests1.hooks.ts
+++ b/src/services/api/testCredentialRequests1/testCredentialRequests1.hooks.ts
@@ -4,6 +4,7 @@ import logger from '../../../logger';
 import { IssuerEntity } from '../../../entities/Issuer';
 import { config } from '../../../config';
 import { handleUserDidAssociation } from '../../hooks/handleUserDidAssociation';
+import { validateCredentialRequest } from '../../hooks/validateCredentialRequest';
 
 export const getIssuerEntity: Hook = async (ctx) => {
   const issuerDataService = ctx.app.service('issuerData');
@@ -25,21 +26,9 @@ export const getIssuerEntity: Hook = async (ctx) => {
   }
 };
 
-export const validateRequest: Hook = async (ctx) => {
-  const { params } = ctx;
-
-  if (!params.headers?.version) {
-    logger.info('CredentialRequest request made without version');
-  } else {
-    logger.info(`CredentialRequest request made with version ${params.headers?.version}`);
-  }
-
-  return ctx;
-};
-
 export const hooks = {
   before: {
-    all: [validateRequest],
+    all: [validateCredentialRequest],
     create: [getIssuerEntity, handleUserDidAssociation]
   },
   after: {}

--- a/src/services/api/testCredentialRequests2/testCredentialRequests2.hooks.ts
+++ b/src/services/api/testCredentialRequests2/testCredentialRequests2.hooks.ts
@@ -1,35 +1,12 @@
-import { Hook } from '@feathersjs/feathers';
-
-import logger from '../../../logger';
-import { IssuerEntity } from '../../../entities/Issuer';
 import { config } from '../../../config';
+import { getIssuerEntity } from '../../hooks/getIssuerEntity';
 import { handleUserDidAssociation } from '../../hooks/handleUserDidAssociation';
 import { validateCredentialRequest } from '../../hooks/validateCredentialRequest';
-
-export const getIssuerEntity: Hook = async (ctx) => {
-  const issuerDataService = ctx.app.service('issuerData');
-  let issuerEntity: IssuerEntity;
-  try {
-    issuerEntity = await issuerDataService.getByDid(config.TEST_ISSUER_DID_2);
-
-    return {
-      ...ctx,
-      params: {
-        ...ctx.params,
-        issuerEntity
-      }
-
-    };
-  } catch (e) {
-    logger.error('getIssuerEntity hook caught an error thrown by issuerDataService.getByDid', e);
-    throw e;
-  }
-};
 
 export const hooks = {
   before: {
     all: [validateCredentialRequest],
-    create: [getIssuerEntity, handleUserDidAssociation]
+    create: [getIssuerEntity(config.TEST_ISSUER_DID_2), handleUserDidAssociation]
   },
   after: {}
 };

--- a/src/services/api/testCredentialRequests2/testCredentialRequests2.hooks.ts
+++ b/src/services/api/testCredentialRequests2/testCredentialRequests2.hooks.ts
@@ -2,10 +2,8 @@ import { Hook } from '@feathersjs/feathers';
 
 import logger from '../../../logger';
 import { IssuerEntity } from '../../../entities/Issuer';
-import { User } from '../../../entities/User';
-import { UnumDto, revokeAllCredentials, VerifiedStatus, verifySignedDid } from '@unumid/server-sdk';
-import { SubjectCredentialRequestsEnrichedDto } from '@unumid/types';
 import { config } from '../../../config';
+import { handleUserDidAssociation } from '../../hooks/handleUserDidAssociation';
 
 export const getIssuerEntity: Hook = async (ctx) => {
   const issuerDataService = ctx.app.service('issuerData');
@@ -37,95 +35,6 @@ export const validateRequest: Hook = async (ctx) => {
   }
 
   return ctx;
-};
-
-/**
- * Grab and return the associated user. If useDidAssociation is passed update the user with the provided did.
- * @param ctx
- * @returns
- */
-export const handleUserDidAssociation: Hook = async (ctx) => {
-  const { app, params } = ctx;
-
-  // need to get an existing user either by the userIdentifier or by the subjectDid
-  const userDataService = app.service('userData');
-  let user: User;
-
-  const issuer: IssuerEntity = params?.issuerEntity;
-  const data: SubjectCredentialRequestsEnrichedDto = ctx.data;
-
-  const { userDidAssociation, credentialRequestsInfo: { subjectDid } } = data;
-
-  // if no userDidAssociation as part of request body then it is assume this issuer already has the did associated with a user
-  if (!userDidAssociation) {
-    logger.debug('No new userDidAssociation in the userCredentialRequests');
-
-    // grabbing user by subjectDid
-    try {
-      user = await userDataService.get(null, { where: { did: subjectDid } }); // will throw exception if not found
-    } catch (e) {
-      logger.warn(`No user found with did ${subjectDid}. This should never happen.`);
-      throw e;
-    }
-
-    return {
-      ...ctx,
-      data: {
-        ...ctx.data,
-        user
-      }
-    };
-  }
-
-  const { userCode, did } = userDidAssociation;
-
-  try {
-    // assuming user code is the object id... TODO change to query based on attribute
-    user = await userDataService.get(null, { where: { userCode } }); // will throw exception if not found
-  } catch (e) {
-    logger.warn(`No user found with code ${userCode}. Can not associate the did ${did.id}.`);
-    throw e;
-  }
-
-  // verify the subject did document
-  const result: UnumDto<VerifiedStatus> = await verifySignedDid(issuer.authToken, issuer.issuerDid, did);
-
-  if (!result.body.isVerified) {
-    throw new Error(`${result.body.message} Subject DID document ${did.id} for user ${userCode} is not verified.`);
-  }
-
-  const userDid = did.id;
-
-  // if this is a new did association for the user then we need to revoke all the credentials associated with teh old did document
-  if (userDid !== user.did) {
-    // revoke all credentials associated with old did
-    await revokeAllCredentials(issuer.authToken, issuer.issuerDid, issuer.privateKey, userDid);
-
-    // update the user with the new did
-    await userDataService.patch(null, { did: userDid, userCode: null }, { where: { userCode } });
-  } else {
-    logger.debug('User association information sent with identical user did information. This should never happen.');
-    await userDataService.patch(null, { userCode: null }, { where: { userCode } }); // remove the userCode from the user
-  }
-
-  // update the default issuer's auth token if it has been reissued
-  if (result.authToken !== issuer.authToken) {
-    const issuerDataService = app.service('issuerData');
-    try {
-      await issuerDataService.patch(issuer.uuid, { authToken: result.authToken });
-    } catch (e) {
-      logger.error('CredentialRequest create caught an error thrown by issuerDataService.patch', e);
-      throw e;
-    }
-  }
-
-  return {
-    ...ctx,
-    data: {
-      ...ctx.data,
-      user
-    }
-  };
 };
 
 export const hooks = {

--- a/src/services/api/testCredentialRequests2/testCredentialRequests2.hooks.ts
+++ b/src/services/api/testCredentialRequests2/testCredentialRequests2.hooks.ts
@@ -4,6 +4,7 @@ import logger from '../../../logger';
 import { IssuerEntity } from '../../../entities/Issuer';
 import { config } from '../../../config';
 import { handleUserDidAssociation } from '../../hooks/handleUserDidAssociation';
+import { validateCredentialRequest } from '../../hooks/validateCredentialRequest';
 
 export const getIssuerEntity: Hook = async (ctx) => {
   const issuerDataService = ctx.app.service('issuerData');
@@ -25,21 +26,9 @@ export const getIssuerEntity: Hook = async (ctx) => {
   }
 };
 
-export const validateRequest: Hook = async (ctx) => {
-  const { params } = ctx;
-
-  if (!params.headers?.version) {
-    logger.info('CredentialRequest request made without version');
-  } else {
-    logger.info(`CredentialRequest request made with version ${params.headers?.version}`);
-  }
-
-  return ctx;
-};
-
 export const hooks = {
   before: {
-    all: [validateRequest],
+    all: [validateCredentialRequest],
     create: [getIssuerEntity, handleUserDidAssociation]
   },
   after: {}

--- a/src/services/api/userCredentialRequests/userCredentialRequests.hooks.ts
+++ b/src/services/api/userCredentialRequests/userCredentialRequests.hooks.ts
@@ -1,34 +1,12 @@
-import { Hook } from '@feathersjs/feathers';
-
-import logger from '../../../logger';
-import { IssuerEntity } from '../../../entities/Issuer';
 import { handleUserDidAssociation } from '../../hooks/handleUserDidAssociation';
 import { validateCredentialRequest } from '../../hooks/validateCredentialRequest';
-
-export const getDefaultIssuerEntity: Hook = async (ctx) => {
-  const issuerDataService = ctx.app.service('issuerData');
-  let defaultIssuerEntity: IssuerEntity;
-  try {
-    defaultIssuerEntity = await issuerDataService.getDefaultIssuerEntity();
-
-    return {
-      ...ctx,
-      params: {
-        ...ctx.params,
-        defaultIssuerEntity
-      }
-
-    };
-  } catch (e) {
-    logger.error('getDefaultIssuerEntity hook caught an error thrown by issuerDataService.getDefaultIssuerEntity', e);
-    throw e;
-  }
-};
+import { config } from '../../../config';
+import { getIssuerEntity } from '../../hooks/getIssuerEntity';
 
 export const hooks = {
   before: {
     all: [validateCredentialRequest],
-    create: [getDefaultIssuerEntity, handleUserDidAssociation]
+    create: [getIssuerEntity(config.DEFAULT_ISSUER_DID), handleUserDidAssociation]
   },
   after: {}
 };

--- a/src/services/api/userCredentialRequests/userCredentialRequests.hooks.ts
+++ b/src/services/api/userCredentialRequests/userCredentialRequests.hooks.ts
@@ -2,9 +2,7 @@ import { Hook } from '@feathersjs/feathers';
 
 import logger from '../../../logger';
 import { IssuerEntity } from '../../../entities/Issuer';
-import { User } from '../../../entities/User';
-import { UnumDto, revokeAllCredentials, VerifiedStatus, verifySignedDid } from '@unumid/server-sdk';
-import { SubjectCredentialRequestsEnrichedDto } from '@unumid/types';
+import { handleUserDidAssociation } from '../../hooks/handleUserDidAssociation';
 
 export const getDefaultIssuerEntity: Hook = async (ctx) => {
   const issuerDataService = ctx.app.service('issuerData');
@@ -36,95 +34,6 @@ export const validateRequest: Hook = async (ctx) => {
   }
 
   return ctx;
-};
-
-/**
- * Grab and return the associated user. If useDidAssociation is passed update the user with the provided did.
- * @param ctx
- * @returns
- */
-export const handleUserDidAssociation: Hook = async (ctx) => {
-  const { app, params } = ctx;
-
-  // need to get an existing user either by the userIdentifier or by the subjectDid
-  const userDataService = app.service('userData');
-  let user: User;
-
-  const issuer: IssuerEntity = params?.defaultIssuerEntity;
-  const data: SubjectCredentialRequestsEnrichedDto = ctx.data;
-
-  const { userDidAssociation, credentialRequestsInfo: { subjectDid } } = data;
-
-  // if no userDidAssociation as part of request body then it is assume this issuer already has the did associated with a user
-  if (!userDidAssociation) {
-    logger.debug('No new userDidAssociation in the userCredentialRequests');
-
-    // grabbing user by subjectDid
-    try {
-      user = await userDataService.get(null, { where: { did: subjectDid } }); // will throw exception if not found
-    } catch (e) {
-      logger.warn(`No user found with did ${subjectDid}. This should never happen.`);
-      throw e;
-    }
-
-    return {
-      ...ctx,
-      data: {
-        ...ctx.data,
-        user
-      }
-    };
-  }
-
-  const { userCode, did } = userDidAssociation;
-
-  try {
-    // assuming user code is the object id... TODO change to query based on attribute
-    user = await userDataService.get(null, { where: { userCode } }); // will throw exception if not found
-  } catch (e) {
-    logger.warn(`No user found with code ${userCode}. Can not associate the did ${did.id}.`);
-    throw e;
-  }
-
-  // verify the subject did document
-  const result: UnumDto<VerifiedStatus> = await verifySignedDid(issuer.authToken, issuer.issuerDid, did);
-
-  if (!result.body.isVerified) {
-    throw new Error(`${result.body.message} Subject DID document ${did.id} for user ${userCode} is not verified.`);
-  }
-
-  const userDid = did.id;
-
-  // if this is a new did association for the user then we need to revoke all the credentials associated with teh old did document
-  if (userDid !== user.did) {
-    // revoke all credentials associated with old did
-    await revokeAllCredentials(issuer.authToken, issuer.issuerDid, issuer.privateKey, userDid);
-
-    // update the user with the new did
-    await userDataService.patch(null, { did: userDid, userCode: null }, { where: { userCode } });
-  } else {
-    logger.debug('User association information sent with identical user did information. This should never happen.');
-    await userDataService.patch(null, { userCode: null }, { where: { userCode } }); // remove the userCode from the user
-  }
-
-  // update the default issuer's auth token if it has been reissued
-  if (result.authToken !== issuer.authToken) {
-    const issuerDataService = app.service('issuerData');
-    try {
-      await issuerDataService.patch(issuer.uuid, { authToken: result.authToken });
-    } catch (e) {
-      logger.error('CredentialRequest create caught an error thrown by issuerDataService.patch', e);
-      throw e;
-    }
-  }
-
-  return {
-    ...ctx,
-    data: {
-      ...ctx.data,
-      user
-    }
-  };
 };
 
 export const hooks = {

--- a/src/services/api/userCredentialRequests/userCredentialRequests.hooks.ts
+++ b/src/services/api/userCredentialRequests/userCredentialRequests.hooks.ts
@@ -3,6 +3,7 @@ import { Hook } from '@feathersjs/feathers';
 import logger from '../../../logger';
 import { IssuerEntity } from '../../../entities/Issuer';
 import { handleUserDidAssociation } from '../../hooks/handleUserDidAssociation';
+import { validateCredentialRequest } from '../../hooks/validateCredentialRequest';
 
 export const getDefaultIssuerEntity: Hook = async (ctx) => {
   const issuerDataService = ctx.app.service('issuerData');
@@ -24,21 +25,9 @@ export const getDefaultIssuerEntity: Hook = async (ctx) => {
   }
 };
 
-export const validateRequest: Hook = async (ctx) => {
-  const { params } = ctx;
-
-  if (!params.headers?.version) {
-    logger.info('CredentialRequest request made without version');
-  } else {
-    logger.info(`CredentialRequest request made with version ${params.headers?.version}`);
-  }
-
-  return ctx;
-};
-
 export const hooks = {
   before: {
-    all: [validateRequest],
+    all: [validateCredentialRequest],
     create: [getDefaultIssuerEntity, handleUserDidAssociation]
   },
   after: {}

--- a/src/services/hooks/getIssuerEntity.ts
+++ b/src/services/hooks/getIssuerEntity.ts
@@ -1,0 +1,26 @@
+import { Hook } from '@feathersjs/feathers';
+import { IssuerEntity } from '../../entities/Issuer';
+import logger from '../../logger';
+
+export const getIssuerEntity: (did: string) => Hook = (did: string) => async (ctx) => {
+  console.log('getIssuerEntity');
+  console.log('did', did);
+  const issuerDataService = ctx.app.service('issuerData');
+  let issuerEntity: IssuerEntity;
+  try {
+    issuerEntity = await issuerDataService.getByDid(did);
+    console.log('issuerEntity', issuerEntity);
+
+    return {
+      ...ctx,
+      params: {
+        ...ctx.params,
+        issuerEntity
+      }
+
+    };
+  } catch (e) {
+    logger.error('getIssuerEntity hook caught an error thrown by issuerDataService.getByDid', e);
+    throw e;
+  }
+};

--- a/src/services/hooks/handleUserDidAssociation.ts
+++ b/src/services/hooks/handleUserDidAssociation.ts
@@ -1,0 +1,95 @@
+import { Hook } from '@feathersjs/feathers';
+import { revokeAllCredentials, UnumDto, VerifiedStatus, verifySignedDid } from '@unumid/server-sdk';
+import { SubjectCredentialRequestsEnrichedDto } from '@unumid/types';
+import { IssuerEntity } from '../../entities/Issuer';
+import { User } from '../../entities/User';
+import logger from '../../logger';
+
+/**
+ * Grab and return the associated user. If useDidAssociation is passed update the user with the provided did.
+ * @param ctx
+ * @returns
+ */
+export const handleUserDidAssociation: Hook = async (ctx) => {
+  const { app, params } = ctx;
+
+  // need to get an existing user either by the userIdentifier or by the subjectDid
+  const userDataService = app.service('userData');
+  let user: User;
+
+  const issuer: IssuerEntity = params?.defaultIssuerEntity;
+  const data: SubjectCredentialRequestsEnrichedDto = ctx.data;
+
+  const { userDidAssociation, credentialRequestsInfo: { subjectDid } } = data;
+
+  // if no userDidAssociation as part of request body then it is assume this issuer already has the did associated with a user
+  if (!userDidAssociation) {
+    logger.debug('No new userDidAssociation in the userCredentialRequests');
+
+    // grabbing user by subjectDid
+    try {
+      user = await userDataService.get(null, { where: { did: subjectDid } }); // will throw exception if not found
+    } catch (e) {
+      logger.warn(`No user found with did ${subjectDid}. This should never happen.`);
+      throw e;
+    }
+
+    return {
+      ...ctx,
+      data: {
+        ...ctx.data,
+        user
+      }
+    };
+  }
+
+  const { userCode, did } = userDidAssociation;
+
+  try {
+    // assuming user code is the object id... TODO change to query based on attribute
+    user = await userDataService.get(null, { where: { userCode } }); // will throw exception if not found
+  } catch (e) {
+    logger.warn(`No user found with code ${userCode}. Can not associate the did ${did.id}.`);
+    throw e;
+  }
+
+  // verify the subject did document
+  const result: UnumDto<VerifiedStatus> = await verifySignedDid(issuer.authToken, issuer.issuerDid, did);
+
+  if (!result.body.isVerified) {
+    throw new Error(`${result.body.message} Subject DID document ${did.id} for user ${userCode} is not verified.`);
+  }
+
+  const userDid = did.id;
+
+  // if this is a new did association for the user then we need to revoke all the credentials associated with teh old did document
+  if (userDid !== user.did) {
+    // revoke all credentials associated with old did
+    await revokeAllCredentials(issuer.authToken, issuer.issuerDid, issuer.privateKey, userDid);
+
+    // update the user with the new did
+    user = await userDataService.patch(user.uuid, { did: userDid, userCode: null });
+  } else {
+    logger.debug('User association information sent with identical user did information. This should never happen.');
+    user = await userDataService.patch(user.uuid, { userCode: null }); // remove the userCode from the user
+  }
+
+  // update the default issuer's auth token if it has been reissued
+  if (result.authToken !== issuer.authToken) {
+    const issuerDataService = app.service('issuerData');
+    try {
+      user = await issuerDataService.patch(issuer.uuid, { authToken: result.authToken });
+    } catch (e) {
+      logger.error('CredentialRequest create caught an error thrown by issuerDataService.patch', e);
+      throw e;
+    }
+  }
+
+  return {
+    ...ctx,
+    data: {
+      ...ctx.data,
+      user
+    }
+  };
+};

--- a/src/services/hooks/handleUserDidAssociation.ts
+++ b/src/services/hooks/handleUserDidAssociation.ts
@@ -17,7 +17,7 @@ export const handleUserDidAssociation: Hook = async (ctx) => {
   const userDataService = app.service('userData');
   let user: User;
 
-  const issuer: IssuerEntity = params?.defaultIssuerEntity;
+  const issuer: IssuerEntity = params?.issuerEntity;
   const data: SubjectCredentialRequestsEnrichedDto = ctx.data;
 
   const { userDidAssociation, credentialRequestsInfo: { subjectDid } } = data;
@@ -78,7 +78,7 @@ export const handleUserDidAssociation: Hook = async (ctx) => {
   if (result.authToken !== issuer.authToken) {
     const issuerDataService = app.service('issuerData');
     try {
-      user = await issuerDataService.patch(issuer.uuid, { authToken: result.authToken });
+      await issuerDataService.patch(issuer.uuid, { authToken: result.authToken });
     } catch (e) {
       logger.error('CredentialRequest create caught an error thrown by issuerDataService.patch', e);
       throw e;

--- a/src/services/hooks/validateCredentialRequest.ts
+++ b/src/services/hooks/validateCredentialRequest.ts
@@ -1,0 +1,14 @@
+import { Hook } from '@feathersjs/feathers';
+import logger from '../../logger';
+
+export const validateCredentialRequest: Hook = async (ctx) => {
+  const { params } = ctx;
+
+  if (!params.headers?.version) {
+    logger.info('CredentialRequest request made without version');
+  } else {
+    logger.info(`CredentialRequest request made with version ${params.headers?.version}`);
+  }
+
+  return ctx;
+};


### PR DESCRIPTION
## Summary
moves credential request service hooks to shared hooks directory and fixes some bugs in handleUserDidAssociation

## Changes
- moves `handleUserDidAssociation`, `getIssuerEntity` and `validateCredentialRequest` hooks to separate shared hooks
- fixes problem in `handleUserDidAssociation` where it was returning an out of date version of the user object
- adds stack trace and other info to error logs