### PR TITLE
[ci] update aws-eks orb to 2.1.2

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@ version: 2.1
 
 orbs:
   aws-cli: circleci/aws-cli@0.1.22
-  aws-eks: circleci/aws-eks@2.1.1
+  aws-eks: circleci/aws-eks@2.1.2
   kubernetes: circleci/kubernetes@0.4.0
   slack: circleci/slack@4.4.2 # ref: https://github.com/CircleCI-Public/slack-orb, https://circleci.com/developer/orbs/orb/circleci/slack#usage-examples
 


### PR DESCRIPTION
[Ticket](https://trello.com/c/T1zzuXpA/2699-update-aws-eks-orb-everywhere-that-uses-it)